### PR TITLE
Add ec_get(addr) to debug mode

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1657,8 +1657,8 @@ static ssize_t ec_get_store(struct device *dev, struct device_attribute *attr,
 		return -EINVAL;
 
 	int result;
-
 	char addr_s[3];
+
 	result = sscanf(buf, "%2s", addr_s);
 	if (result != 1)
 		return -EINVAL;
@@ -1677,7 +1677,9 @@ static ssize_t ec_get_show(struct device *device,
 			   char *buf)
 {
 	u8 rdata;
-	int result = ec_read(ec_get_addr, &rdata);
+	int result;
+	
+	result = ec_read(ec_get_addr, &rdata);
 	if (result < 0)
 		return result;
 

--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1647,11 +1647,12 @@ static ssize_t ec_set_store(struct device *dev, struct device_attribute *attr,
 }
 
 // ec_get. stores the specified EC memory address. MAY BE UNSAFE!!!
-static u8 ec_get_addr = 0;
+static u8 ec_get_addr;
 
 // ec_get. reads and stores the specified EC memory address. Format: "xx", xx - hex u8
 static ssize_t ec_get_store(struct device *dev, struct device_attribute *attr,
-			    const char *buf, size_t count){
+			    const char *buf, size_t count)
+{
 	if (count > 3) // "xx\n" - 3 chars
 		return -EINVAL;
 
@@ -1673,7 +1674,8 @@ static ssize_t ec_get_store(struct device *dev, struct device_attribute *attr,
 // ec_get. prints value of previously stored EC memory address
 static ssize_t ec_get_show(struct device *device,
 			   struct device_attribute *attr,
-			   char *buf){
+			   char *buf)
+{
 	u8 rdata;
 	int result = ec_read(ec_get_addr, &rdata);
 	if (result < 0)


### PR DESCRIPTION
Add ability to read specific address with RW sysfs attribute. ```ec_get_addr``` storing may be implemented in wrong way, but i don`t know proper implementation.